### PR TITLE
Adjusted the education-entry to allow the user to leave off the "location"

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -353,7 +353,9 @@
     row-gutter: 3mm,
     [#degree-style(title)],
     [#date-style(date)],
-    table.cell(colspan: 2)[#institution-style(company), #location-style(location)],
+    table.cell(colspan: 2)[
+      #institution-style(company)#if location != "Location" [, #location-style(location) ]
+    ],
   )
   v(5pt)
 }

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -333,7 +333,9 @@
     stroke: none,
     row-gutter: 3mm,
     [#degree-style(degree)], [#date-style(date)],
-    [#institution-style(institution), #location-style(location)],
+    [
+      #institution-style(institution)#if location != "Location" [, #location-style(location) ]
+    ],
   )
   v(2pt)
 }


### PR DESCRIPTION
I found I wanted to enter some education entries without specifying a location. This might be desirable for brevity, or because two separate institutions were listed in one degree, or just for personal preference. However, when I did this, there was always a trailing comma, or it would "Location", e.g. "University of Faketown, Location", or "University of Faketown,".

My new version only adds the comma and location if a new "location" was defined.