### PR TITLE
Allow non-square portrait image

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -137,7 +137,11 @@
     box(
       clip: true,
       radius: 50%,
-      photo,
+      square(
+        stroke: none,
+        inset: 0pt,
+        photo,
+      )
     )
   } else {
     box(

--- a/src/template/cv.typ
+++ b/src/template/cv.typ
@@ -2,7 +2,7 @@
 
 // #import meta.import.path: cv
 #import "@preview/grotesk-cv:1.0.4": cv
-#let photo = image("./img/" + meta.personal.profile_image)
+#let photo = image(width: 100%, height: 100%, "./img/" + meta.personal.profile_image)
 
 #let import-sections(
   sections,


### PR DESCRIPTION
Formerly, only photos / portrait images of square measures can be processed.
In the future also allow general rectangle photos to be processed correctly.